### PR TITLE
読んだ記事を日毎表示に

### DIFF
--- a/components/PostSubmitForm.tsx
+++ b/components/PostSubmitForm.tsx
@@ -7,7 +7,6 @@ export default function PostSubmitForm() {
   const { register, handleSubmit, reset, formState: { errors } } = useForm<PostFormType>();
   const router = useRouter();
 
-  // TODO: dataを型付けする
   const onSubmit = async (data: PostFormType) => {
     try {
       const response = await fetch('/api/post', {

--- a/components/PostSubmitForm.tsx
+++ b/components/PostSubmitForm.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import { useRouter } from 'next/router';
 import { PostFormType } from '../types/PostFormType';
 
 export default function PostSubmitForm() {
   const { register, handleSubmit, reset, formState: { errors } } = useForm<PostFormType>();
-  const router = useRouter();
 
   const onSubmit = async (data: PostFormType) => {
     try {
@@ -26,7 +24,7 @@ export default function PostSubmitForm() {
       console.error('Request failed:', error);
       alert('Failed to submit the post. Redirecting to the main page...');
     } finally {
-      router.push('/mypage');
+      window.location.href = '/mypage';
     }
   };
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,7 +14,7 @@ export function parseDateHash(dateHash: string | undefined) {
   }
 
   const year = parseInt(dateHash.substring(0, 4), 10);
-  const month = parseInt(dateHash.substring(4, 6), 10) - 1; // 0から始まるため-1する
+  const month = parseInt(dateHash.substring(4, 6), 10) - 1; // monthは0から始まるため-1する
   const day = parseInt(dateHash.substring(6, 8), 10);
 
   const date = new Date(year, month, day);
@@ -39,13 +39,25 @@ export function areDatesEqual(date1: Date, date2: Date) {
   return year1 === year2 && month1 === month2 && day1 === day2;
 }
 
-export function formatDate(date: Date) {
+export function formatDateForHead(date: Date) {
   const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   const year = date.getFullYear();
-  const month = date.getMonth() + 1; // 0から始まるため+1する
+  const month = date.getMonth() + 1; // monthは0から始まるため+1する
   const day = date.getDate();
   const dayOfWeek = days[date.getDay()];
 
   return `${year}/${month}/${day} ${dayOfWeek}.`;
+}
+
+export function formatDateForHash(date: Date) {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1; // getMonth() は0から始まるため、1を加算
+  const day = date.getDate();
+
+  // 月と日が1桁の場合は先頭に0を付ける
+  const monthStr = month < 10 ? `0${month}` : month.toString();
+  const dayStr = day < 10 ? `0${day}` : day.toString();
+
+  return `${year}${monthStr}${dayStr}`;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,48 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function parseDateHash(dateHash: string | undefined) {
+  const today = new Date(new Date().setHours(0, 0, 0, 0));
+
+  // dateHashが未定義または形式が不正な場合、今日の0時のDateオブジェクトを返す
+  if (!dateHash || !/^\d{8}$/.test(dateHash)) {
+    return today;
+  }
+
+  const year = parseInt(dateHash.substring(0, 4), 10);
+  const month = parseInt(dateHash.substring(4, 6), 10) - 1; // 0から始まるため-1する
+  const day = parseInt(dateHash.substring(6, 8), 10);
+
+  const date = new Date(year, month, day);
+
+  // Dateオブジェクトが無効な日付を表す場合、または未来の日付を表す場合、今日の0時のDateオブジェクトを返す
+  if (isNaN(date.getTime()) || date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day || date > today) {
+    return today;
+  }
+
+  return date;
+}
+
+export function areDatesEqual(date1: Date, date2: Date) {
+  const year1 = date1.getFullYear();
+  const month1 = date1.getMonth();
+  const day1 = date1.getDate();
+
+  const year2 = date2.getFullYear();
+  const month2 = date2.getMonth();
+  const day2 = date2.getDate();
+
+  return year1 === year2 && month1 === month2 && day1 === day2;
+}
+
+export function formatDate(date: Date) {
+  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1; // 0から始まるため+1する
+  const day = date.getDate();
+  const dayOfWeek = days[date.getDay()];
+
+  return `${year}/${month}/${day} ${dayOfWeek}.`;
+}

--- a/types/PostType.ts
+++ b/types/PostType.ts
@@ -9,4 +9,5 @@ export type PostType = {
     ogImage?: any;
   };
   userId: string;
+  createdAt: string;
 }


### PR DESCRIPTION
# 概要

- マイページにて、投稿を日別表示できるようにした

# 変更点

- マイページのURLのハッシュでどの日に投稿された記事を表示するか判定する
    - `/mypage#YYYYMMDD`
    - ハッシュなし（`/mypage`）の場合、今日投稿された記事を表示
    - ハッシュが不正な形式の場合は`/mypage`に遷移
    - ハッシュが今日、未来の日付の場合は`/mypage`に遷移

# 関連Issue
