### PR TITLE
ダークモードのコメントフォームの文字色を修正

### DIFF
--- a/components/PostSubmitForm.tsx
+++ b/components/PostSubmitForm.tsx
@@ -38,14 +38,14 @@ export default function PostSubmitForm() {
           Share an article you read today:
         </label>
         <input
-          className="p-2 border border-gray-200 border-gray-300 rounded-md dark:border-gray-800"
+          className="p-2 border border-gray-200 border-gray-300 rounded-md focus:border-gray-400 focus:outline-none"
           placeholder="Enter article URL"
           id="url"
           type="url"
           {...register('url', { required: true })}
         />
         <textarea
-          className="p-2 border border-gray-200 border-gray-300 rounded-md mt-2 dark:border-gray-800 dark:text-black"
+          className="p-2 border border-gray-200 border-gray-300 rounded-md mt-2 dark:text-black focus:border-gray-400 focus:outline-none"
           id="comment"
           placeholder="Enter your comment"
           {...register('comment')}

--- a/components/PostSubmitForm.tsx
+++ b/components/PostSubmitForm.tsx
@@ -45,7 +45,7 @@ export default function PostSubmitForm() {
           {...register('url', { required: true })}
         />
         <textarea
-          className="p-2 border border-gray-200 border-gray-300 rounded-md mt-2 dark:border-gray-800"
+          className="p-2 border border-gray-200 border-gray-300 rounded-md mt-2 dark:border-gray-800 dark:text-black"
           id="comment"
           placeholder="Enter your comment"
           {...register('comment')}


### PR DESCRIPTION
# 概要

- ダークモードでコメントフォームの文字が見えない問題を解消

# 変更点

- ダークモードのコメントフォームの文字色を黒に指定
- ダークモードのURL、コメントフォームの枠線の色をライトモードと同じに変更
- URL、コメントフォームにフォーカスされた時の枠線の色を青からグレーに変更

# 関連Issue
- close #29 
