### PR TITLE
タイムゾーンを日本時間に

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,15 +6,17 @@ export default function Header() {
   const { user } = useUser();
   return(
     <header className="flex justify-between items-center mb-4">
-      <div className="flex items-center gap-1">
-        <Image
-          alt="icon"
-          height="48"
-          src="/penguin.png"
-          width="48"
-        />
-        <h1 className="text-3xl font-bold text-white">{"Today's Tech Reads"}</h1>
-      </div>
+        <Link href="/">
+          <div className="flex items-center gap-1">
+            <Image
+              alt="icon"
+              height="48"
+              src="/penguin.png"
+              width="48"
+            />
+            <h1 className="text-3xl font-bold text-white">{"Today's Tech Reads"}</h1>
+          </div>
+        </Link>
         {user ? (
           <div className="flex gap-4 items-center">
             <Link

--- a/components/Ice.tsx
+++ b/components/Ice.tsx
@@ -16,8 +16,8 @@ export default function Ice({ selectedDate, setSelectedDate, postCountByDate }: 
     const lastDay = new Date(year, month + 1, 0);
     const map = new Map<string, number>();
 
-    for(let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)){
-      const formattedDate = day.toISOString().split('T')[0];
+    for(let date = firstDay; date <= lastDay; date.setDate(date.getDate() + 1)){
+      const formattedDate = date.toLocaleString('ja-JP', { year: "numeric", month: '2-digit', day: '2-digit' });
       const count = postCountByDate.get(formattedDate) || 0;
       map.set(formattedDate, count);
     }

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -42,7 +42,8 @@ export default function MyPage({ posts }: PropsType ) {
     const map = new Map<string, number>();
     posts.forEach((post) => {
       const date = new Date(post.createdAt);
-      const formattedDate = date.toISOString().split('T')[0];
+      // 日本時間でYYYY/MM/DDの形式
+      const formattedDate = date.toLocaleString('ja-JP', { year: "numeric", month: '2-digit', day: '2-digit' });
       const count = map.get(formattedDate) || 0;
       map.set(formattedDate, count + 1);
     })


### PR DESCRIPTION
# 概要

- `production`環境で`Ice`の表示ズレが起きていた
    - VercelのタイムゾーンはUTC
    - `development`環境のタイムゾンは`Asia/Tokyo`

# 変更点

- `/mypage`および`Ice`コンポーネントにおいて、`postCountByDate`の計算をすべて日本時間で行うように修正
- Vercel側でビルドコマンドに`TZ=Asia/Tokyo`を追加
    - Vercelでは`TZ`が環境変数の予約語になっているので環境変数側からは設定できない
- ついでにヘッダーのロゴにトップページへのリンクを追加した

# 関連Issue
