### PR TITLE
ランキングページに表示する記事を1週間以内のものに限定

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -61,3 +61,17 @@ export function formatDateForHash(date: Date) {
 
   return `${year}${monthStr}${dayStr}`;
 }
+
+export function formatDateForWeeklyRanking(endDate: Date) {
+  const startDate = new Date();
+  startDate.setDate(endDate.getDate() - 7);
+  const startYear = startDate.getFullYear();
+  const startMonth = startDate.getMonth() + 1;
+  const startDay = startDate.getDate();
+
+  const endYear = endDate.getFullYear();
+  const endMonth = endDate.getMonth() + 1; // monthは0から始まるため+1する
+  const endDay = endDate.getDate();
+
+  return `${startYear}/${startMonth}/${startDay} - ${endYear}/${endMonth}/${endDay}`;
+}

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -67,7 +67,6 @@ export default function MyPage({ posts }: PropsType ) {
   // selectedDateの変更をURLハッシュに反映
   useEffect(() => {
     const selectedPosts = filterdPosts(selectedDate);
-    const today = new Date();
     setSelectedPosts(selectedPosts);
 
     const hash = formatDateForHash(selectedDate);

--- a/pages/ranking.tsx
+++ b/pages/ranking.tsx
@@ -33,17 +33,28 @@ export default function MyPage({ articles }: PropsType ) {
 }
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-    const articles = await prisma.article.findMany({
-      select: {
-        id: true,
-        url: true,
-        posts: {
-          select: {
-            id: true,
-          }
-        }
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+  const articles = await prisma.article.findMany({
+    where: {
+      posts: {
+        some: {
+          createdAt: {
+            gte: oneWeekAgo,
+          },
+        },
       },
-    });
+    },
+    select: {
+      id: true,
+      url: true,
+      posts: {
+        select: {
+          id: true,
+        }
+      }
+    }});
     const articlesWithMetadata = await Promise.all(articles.map(async article => {
       const metadata = await fetchMetadata(article.url);
       return {

--- a/pages/ranking.tsx
+++ b/pages/ranking.tsx
@@ -5,12 +5,14 @@ import prisma from '../lib/prisma';
 import { ArticleType } from '../types/ArticleType';
 import { fetchMetadata } from '@/lib/fetchMetadata';
 import Footer from '../components/Footer';
+import { formatDateForWeeklyRanking } from '../lib/utils';
 
 type PropsType = {
   articles: ArticleType[];
 }
 
 export default function MyPage({ articles }: PropsType ) {
+  const today = new Date();
   const sortedArticles = [...articles].sort((a, b) => {
     return b.posts.length - a.posts.length
   })
@@ -19,8 +21,9 @@ export default function MyPage({ articles }: PropsType ) {
       <div className="max-w-2xl mx-auto">
         <Header />
         <div className="grid gap-4">
-          <div className="flex items-center justify-center space-x-2 text-2xl font-bold text-[#000000]">
-            <span>Ranking</span>
+          <div className="flex flex-col items-center justify-center space-y-2">
+            <span className="text-2xl font-bold text-[#000000]">Weekly Ranking</span>
+            <span>{formatDateForWeeklyRanking(today)}</span>
           </div>
           {sortedArticles.map((article, index) => (
             <Article key={index} article={article} />


### PR DESCRIPTION
# 概要

- Rankingページで表示する`Article`を1週間以内のものにした

# 変更点

- Rankingページで取得する`Article`を、`createdAt`が1週間以内の`Post`を子レコードとして持つものだけにした
- Rankingページの上部に期間（`YYYY/MM/DD - YYYY/MM/DD`）を入れた

# 関連Issue
close #14 