### PR TITLE
記事のタイトル表示のバグ修正

### DIFF
--- a/lib/fetchMetadata.ts
+++ b/lib/fetchMetadata.ts
@@ -1,13 +1,13 @@
 import axios from 'axios';
-import cheerio from 'cheerio';
+import { load } from 'cheerio';
 
 export async function fetchMetadata (url: string) {
   try {
     const response = await axios.get(url);
     const html = response.data;
-    const $ = cheerio.load(html);
+    const $ = load(html);
 
-    const title = $('title').text();
+    const title = $('title').first().text();
     const description = $('meta[name="description"]').attr('content') || $('meta[property="og:description"]').attr('content');
     const ogImage = $('meta[property="og:image"]').attr('content');
 


### PR DESCRIPTION
# 概要

# 変更点
- ランキングページなどで表示する記事のタイトルについて、一番最初のtitleタグのテキストを表示するようにした
    - Zennの記事はtitleタグが複数あったため、記事のタイトルに不要な「ZennZenn」が末尾に表示されていた

# 変更しなかった点
- Zennの記事はそもそもmetaタグのdescriptionが設定されていなかったため、概要は表示しないことにした。

# 関連Issue
- close #8 